### PR TITLE
Fix invalid Windows CMD syntax

### DIFF
--- a/makeportable2.cmd
+++ b/makeportable2.cmd
@@ -15,13 +15,15 @@ if not "%~1" == "" (
 tar xvf "%installer%" iTunes64.msi
 if %errorlevel% == 1 (
     tar xvf "%installer%" iTunes.msi
-) else not %errorlevel% == 0 (
+) else if not %errorlevel% == 0 (
     for /F "tokens=1,2*" %%i in ('reg query HKLM\Software\7-Zip /v Path') do (
         set "PATH=%%k;%PATH%"
     )
     7z e -y "%installer%" iTunes64.msi
-    if %errorlevel% == 0 and not exist iTunes64.msi (
-        7z e -y "%installer%" iTunes.msi
+    if !errorlevel! == 0 (
+        if not exist iTunes64.msi (
+            7z e -y "%installer%" iTunes.msi
+        )
     )
 )
 


### PR DESCRIPTION
> 'not' is not recognized as an internal or external command,
> operable program or batch file.

https://github.com/nu774/makeportable/blob/dd34df896d797b4bb3aeed3b6bd492be363fcb22/makeportable2.cmd#L18
This line should be `) else if not %errorlevel% == 0 (`.
___

https://github.com/nu774/makeportable/blob/dd34df896d797b4bb3aeed3b6bd492be363fcb22/makeportable2.cmd#L22-L25
I changed `%errorlevel%` to `!errorlevel!` for proper delayed expansion.

> 'and' is not recognized as an internal or external command,
> operable program or batch file.

Used nested if statements 

```
    if !errorlevel! == 0 (
        if not exist iTunes64.msi (
            7z e -y "%installer%" iTunes.msi
        )
    )
```
___

**Stuff to consider (running script from file explore):**
Add `pushd "%~dp0"` to the start of the script so that if you start the script as admin (working directory usually set to system32) it can find the iTunes installer in the scripts directory.
Note: If the iTunes installer is dragged and dropped, extracted files will output to the script's directory instead of the installer's directory.

Add pause at the end of the script to allow users to view console output before the window closes.